### PR TITLE
minor-fix

### DIFF
--- a/stdplugins/download.py
+++ b/stdplugins/download.py
@@ -47,7 +47,7 @@ async def _(event):
         file_name = os.path.basename(url)
         to_download_directory = Config.TMP_DOWNLOAD_DIRECTORY
         if "|" in input_str:
-            url, file_name = input_str.split("|")
+            url, file_name = input_str.split("|", maxsplit = 1)
         url = url.strip()
         file_name = file_name.strip()
         downloaded_file_name = os.path.join(to_download_directory, file_name)
@@ -64,17 +64,18 @@ async def _(event):
             speed = downloader.get_speed()
             elapsed_time = round(diff) * 1000
             progress_str = "[{0}{1}]\nProgress: {2}%".format(
-                ''.join(["█" for i in range(math.floor(percentage / 5))]),
-                ''.join(["░" for i in range(20 - math.floor(percentage / 5))]),
+                ''.join(["█" for _ in range(math.floor(percentage / 5))]),
+                ''.join(["░" for _ in range(20 - math.floor(percentage / 5))]),
                 round(percentage, 2))
             estimated_total_time = downloader.get_eta(human=True)
             try:
-                current_message = f"trying to download\n"
-                current_message += f"URL: {url}\n"
-                current_message += f"File Name: {file_name}\n"
-                current_message += f"{progress_str}\n"
-                current_message += f"{humanbytes(downloaded)} of {humanbytes(total_length)}\n"
-                current_message += f"ETA: {estimated_total_time}"
+                current_message = f"trying to download\n"\
+                                  f"URL: {url}\n"\
+                                  f"File Name: {file_name}\n" \
+                                  f"Speed: {speed}"\
+                                  f"{progress_str}\n"\
+                                  f"{humanbytes(downloaded)} of {humanbytes(total_length)}\n"\
+                                  f"ETA: {estimated_total_time}"
                 if round(diff % 10.00) == 0 and current_message != display_message:
                     await mone.edit(current_message)
                     display_message = current_message

--- a/stdplugins/tb_button.py
+++ b/stdplugins/tb_button.py
@@ -39,7 +39,7 @@ async def _(event):
 
         # if even, not escaped -> create button
         if n_escapes % 2 == 0:
-            # create a thruple with button label, url, and newline status
+            # create a tuple with button label, url, and newline status
             buttons.append((match.group(2), match.group(3), bool(match.group(4))))
             note_data += markdown_note[prev:match.start(1)]
             prev = match.end(1)

--- a/stdplugins/telegraph.py
+++ b/stdplugins/telegraph.py
@@ -67,7 +67,7 @@ async def _(event):
                     r_message,
                     Config.TMP_DOWNLOAD_DIRECTORY
                 )
-                m_list = None
+                m_list = ''
                 with open(downloaded_file_name, "rb") as fd:
                     m_list = fd.readlines()
                 for m in m_list:

--- a/uniborg/util.py
+++ b/uniborg/util.py
@@ -95,8 +95,8 @@ async def progress(current, total, event, start, type_of_ps):
         time_to_completion = round((total - current) / speed) * 1000
         estimated_total_time = elapsed_time + time_to_completion
         progress_str = "[{0}{1}]\nPercent: {2}%\n".format(
-            ''.join(["█" for i in range(math.floor(percentage / 5))]),
-            ''.join(["░" for i in range(20 - math.floor(percentage / 5))]),
+            ''.join(["█" for _ in range(math.floor(percentage / 5))]),
+            ''.join(["░" for _ in range(20 - math.floor(percentage / 5))]),
             round(percentage, 2))
         tmp = progress_str + \
             "{0} of {1}\nETA: {2}".format(


### PR DESCRIPTION
Just some minor day-to-day fixes.

`stdplugins/download.py` 
- Added `maxsplit` params, handles even if filename contains "|"
- `_` is used as var name, since we're not using it anywhere (same for `uniborg/util.py`)
- Clubbed all string concatenates to just one big `f-string`

`stdplugins/tb_button.py`
- Fix Typo

`stdplugins/telegraph.py`
- if `m_list is None` then it'll throw an `TypeError`. So initialised as an empty string