### PR TITLE
Changed heroku-postgresql Version

### DIFF
--- a/app.json
+++ b/app.json
@@ -142,7 +142,7 @@
   "addons": [{
     "plan": "heroku-postgresql",
     "options": {
-      "version": "9.5"
+      "version": "10"
     }
   }],
   "buildpacks": [{

--- a/app.json
+++ b/app.json
@@ -142,7 +142,7 @@
   "addons": [{
     "plan": "heroku-postgresql",
     "options": {
-      "version": "10"
+      "version": "12"
     }
   }],
   "buildpacks": [{


### PR DESCRIPTION
Heroku Log : "An error was encountered when contacting the add-on partner to create heroku-postgresql:hobby-dev: Available versions are 9.6, 10, 11, 12 (the default is 12)"
12 (default)
11
![Screenshot (5)](https://user-images.githubusercontent.com/52099763/87123469-6dc0d300-c2a4-11ea-9917-fecd846ec322.png)
![Screenshot (6)](https://user-images.githubusercontent.com/52099763/87123521-88934780-c2a4-11ea-9b03-0a45021fc346.png)


10
9.6
9.5 - deprecating